### PR TITLE
Add key-quiz-matching-regex customize variable

### DIFF
--- a/key-quiz.el
+++ b/key-quiz.el
@@ -58,6 +58,11 @@
   "Number of questions per game."
   :type 'integer)
 
+(defcustom key-quiz-matching-regexp "^<?[MC]"
+  "Regexp used to match valid mappings in the quiz.
+The regexp should start with ^ and be valid for `delete-non-matching-lines'."
+  :type 'string)
+
 (defcustom key-quiz--mode 'fundamental-mode
   "Mode to use when fetching key list."
   :type 'function)
@@ -130,7 +135,7 @@ list is generated using `describe-buffer-bindings' on
       (funcall key-quiz--mode)
       (describe-buffer-bindings (current-buffer))
       (goto-char (point-min))
-      (delete-non-matching-lines "^<?[MC]")
+      (delete-non-matching-lines key-quiz-matching-regexp)
       (delete-matching-lines
        "Prefix Command\\|Keyboard Macro\\|mouse\\|C-g\\|\\.\\.")
       (while (not (eobp))


### PR DESCRIPTION
I wanted to make the key-quiz work with my evil keybindings, and I understood that they didn't appear in the quiz because they were filtered out. The advantage of having a "normal mode" is that I can have relevant key-quiz bindings not starting with `M-` or `C-`

So this pull request makes the argument of `delete-non-matching-lines` a custom variable so anyone can change their filter (I use `"^<?[MCSgz]` to test the code locally, and get the SPC mappings I set for myself, and the g, z mappings from evil-normal-state)